### PR TITLE
Fix the NS HTML request engine and support fast site

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -72,6 +72,15 @@ export class NSScript {
 	}
 
 	/**
+	 * Decides which NationStates domain to send requests to.
+	 * @returns fast.nationstates.net if on the fast site, www.nationstates.net otherwise.
+	 */
+	private getRequestDomain(): string {
+		if(window.location.host == "fast.nationstates.net") return "fast.nationstates.net";
+		return "www.nationstates.net";
+	}
+
+	/**
 	 * Makes a request to a page on the NationStates HTML site.
 	 * @param pagePath The path to the page on NationStates (e.g., "index.html", "page=create_nation").
 	 *                This path is relative to "https://www.nationstates.net/".
@@ -93,7 +102,7 @@ export class NSScript {
 		simultaneity.handleLock(this); // Locks submit buttons and sets the request in progress state
 		try {
 			this.statusBubble.info(`Loading: ${pagePath}...`);
-			const baseUrl = "https://www.nationstates.net/";
+			const baseUrl = `https://${this.getRequestDomain()}/`;
 
 			// Construct the value for the 'script' parameter
 			const scriptParamValue = `${this.scriptName} v${this.scriptVersion} by ${this.scriptAuthor} in use by ${this.currentUser}`;

--- a/src/client.ts
+++ b/src/client.ts
@@ -98,12 +98,15 @@ export class NSScript {
 			// Construct the value for the 'script' parameter
 			const scriptParamValue = `${this.scriptName} v${this.scriptVersion} by ${this.scriptAuthor} in use by ${this.currentUser}`;
 
+			// These will be passed as URL search parameters.
 			const requestParams = new URLSearchParams();
+			// These will be passed as form data in the request body.
+			const payloadParams = new URLSearchParams();
 
-			// Add payload data to requestParams if provided
+			// Add payload data to payloadParams if provided
 			if (payload) {
 				Object.entries(payload).forEach(([key, value]) => 
-					requestParams.append(key, String(value)));
+					payloadParams.append(key, String(value)));
 			}
 
 			// Add special parameters
@@ -113,27 +116,28 @@ export class NSScript {
 				requestParams.append("template-overall", "none");
 			}
 
-			// inject auth values
+			// inject auth values into payload
 			//
 			// man past me was such a genius
 			// for figuring out you can do this lmfao
 			const lastKnownChk = localStorage.getItem("lastKnownChk");
 			if (lastKnownChk) {
-				requestParams.append("chk", lastKnownChk);
+				payloadParams.append("chk", lastKnownChk);
 			}
 			const lastKnownLocalid = localStorage.getItem("lastKnownLocalid");
 			if (lastKnownLocalid) {
-				requestParams.append("localid", lastKnownLocalid);
+				payloadParams.append("localid", lastKnownLocalid);
 			}
 
 			// Ensure the baseUrl has a trailing slash for correct URL resolution
 			const safeBaseUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
-			const finalUrl = new URL(pagePath, safeBaseUrl).toString();
+			const finalUrl = new URL(pagePath, safeBaseUrl);
+			finalUrl.search = requestParams.toString();
 
-			const response = await fetch(finalUrl, {
+			const response = await fetch(finalUrl.toString(), {
 				credentials: "include",
 				method: "POST",
-				body: requestParams.toString(),
+				body: payloadParams,
 				redirect: followRedirects ? "follow" : "manual",
 			});
 			return response;

--- a/src/networking/html/handlers/worldAssembly.ts
+++ b/src/networking/html/handlers/worldAssembly.ts
@@ -98,9 +98,8 @@ export async function handleEndorse(
 			nation: nationName,
 			action: "endorse",
 		},
-		false,
 	);
-	const location = response.headers.get("location") || "";
+	const location = response.url;
 
 	if (location.includes(`nation=${canonicalize(nationName)}`)) {
 		context.statusBubble.success(`Endorsed ${prettify(nationName)}`);
@@ -126,9 +125,8 @@ export async function handleUnendorse(
 			nation: nationName,
 			action: "unendorse",
 		},
-		false,
 	);
-	const location = response.headers.get("location") || "";
+	const location = response.url;
 
 	if (location.includes(`nation=${canonicalize(nationName)}`)) {
 		context.statusBubble.success(`Unendorsed ${prettify(nationName)}`);


### PR DESCRIPTION
Previously, the script was passing the payload parameters in the request body as a string, however, we need them as form data for NationStates to accept them. Passing the URLSearchParams directly to `fetch()` (without `toString()`) will automatically encode them as form data (https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body).

Additionally, the `script` and `userclick` parameters need to be passed separately as URL search parameters, not form data, which is why there's now two sets of `URLSearchParams` (`requestParams` and `payloadParams`).

Supporting the fast site is simple enough. Check if we're on the fast site, and if so, make requests to `fast.nationstates.net` instead of `www.nationstates.net`.

One last fix: the endorsement and unendorsement functions check if they were successful by setting "followRequests" to false and checking whether the URL they're redirected to contains "nation=X". However, there is a caveat: `fetch()`, annoyingly, returns an "opaque" response type which does not contain the redirect location when it receives a redirect with `followRequests` set to "manual". Therefore, the only way to check for success is to follow the redirect anyways and then check where we end up with `response.url`.

Previously, the status bubble was showing "Failed to endorse X" even when the endorsement request went through successfully. After this fix, it displays the result of the endorsement request properly.